### PR TITLE
fix: target_os family lint

### DIFF
--- a/src/penv/environment/environment/mod.rs
+++ b/src/penv/environment/environment/mod.rs
@@ -1,12 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::fmt::{self, Display};
 #[cfg(target_family = "unix")]
-{
-    use std::os::unix::fs::{symlink as unix_symlink, PermissionsExt as _};
-}
-use std::os::unix::fs::symlink as unix_symlink;
-#[cfg(target_family = "unix")]
-use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::fs::{symlink as unix_symlink, PermissionsExt as _};
 #[cfg(target_family = "windows")]
 use std::os::windows::fs::symlink_file as windows_symlink_file;
 use std::sync::Arc;


### PR DESCRIPTION
Follow-up to review fix in https://github.com/penumbra-zone/penv/pull/20, which introduced a build failure, but CI was not yet running.

I'm pleased to report that the BuildJet CI runners are working again on this repo, after several days of getting stuck in queued state. 