### PR TITLE
fix: bash env support

### DIFF
--- a/files/bash-hook.j2
+++ b/files/bash-hook.j2
@@ -1,7 +1,7 @@
 _penv_hook() {
   local previous_exit_status=$?;
   trap -- '' SIGINT;
-  eval "$("{{ penv_executable }}" hook bash)";
+  eval "$("{{ penv_executable }}" env bash)";
   trap - SIGINT;
   return $previous_exit_status;
 };


### PR DESCRIPTION
This was a regression I introduced by misunderstanding the subcommands involved. Flubbed a rebase of the very large rename in #18. With this fix, bash support works well for me locally again!