### PR TITLE
Include an allocation for the pcli address for generated network genesis configs

### DIFF
--- a/src/penv/environment/binary/pd.rs
+++ b/src/penv/environment/binary/pd.rs
@@ -33,6 +33,9 @@ impl Binary for PdBinary {
         // NODE_URL
         let configs = configs.context("configs should be set")?;
         let generate_network = configs.get("generate_network").is_some();
+        let allocation_address = configs
+            .get("allocation_address")
+            .expect("allocation_address should be set");
 
         let pd_args = if generate_network {
             vec![
@@ -45,6 +48,8 @@ impl Binary for PdBinary {
                     .get("external-address")
                     .context("external-address should be set")?
                     .to_string(),
+                "--allocation-address".to_string(),
+                allocation_address.to_string(),
             ]
         } else {
             vec![
@@ -63,6 +68,8 @@ impl Binary for PdBinary {
                     .context("external-address should be set")?
                     .to_string(),
                 self.pd_join_url.to_string(),
+                "--allocation-address".to_string(),
+                allocation_address.to_string(),
             ]
         };
         // Execute the pd binary with the given arguments

--- a/src/penv/environment/environment/checkout/environment.rs
+++ b/src/penv/environment/environment/checkout/environment.rs
@@ -148,7 +148,7 @@ impl EnvironmentTrait for CheckoutEnvironment {
         tracing::debug!("seed phrase: {}", seed_phrase);
         let pclientd_binary = self.get_pclientd_binary();
         pclientd_binary.initialize(Some(HashMap::from([(
-            // pass the seed phrase here to avoid keeping in memory long-term
+            // pass the seed phrase here to avoid keeping in memory
             "seed_phrase".to_string(),
             seed_phrase,
         )])))?;
@@ -165,6 +165,11 @@ impl EnvironmentTrait for CheckoutEnvironment {
 
             if self.metadata().generate_network {
                 pd_configs.insert("generate_network".to_string(), "true".to_string());
+
+                // Generated dev networks include a default allocation for convenience.
+                // Fetch the 0-index address of the environment's pcli
+                let address = pcli_binary.get_address(0)?;
+                pd_configs.insert("allocation_address".to_string(), address);
             }
 
             pd_binary.initialize(Some(pd_configs))?;


### PR DESCRIPTION
This changeset adds a default allocation to the configured pcli wallet's address when using `penv create` with the `--generate-network` flag