### PR TITLE
Support `penv manage reset ENV`

### DIFF
--- a/src/penv/environment/binary/pcli.rs
+++ b/src/penv/environment/binary/pcli.rs
@@ -38,7 +38,7 @@ fn extract_address(input: &str) -> Option<String> {
 }
 
 impl PcliBinary {
-    fn pcli_data_dir(&self) -> Utf8PathBuf {
+    pub fn pcli_data_dir(&self) -> Utf8PathBuf {
         self.root_dir.join("pcli")
     }
 }

--- a/src/penv/environment/environment/mod.rs
+++ b/src/penv/environment/environment/mod.rs
@@ -192,3 +192,12 @@ pub fn create_symlink(target: &Utf8PathBuf, link: &Utf8PathBuf) -> Result<()> {
 
     Ok(())
 }
+
+impl Environments {
+    pub fn get_environment(&self, environment_alias: &str) -> Option<Arc<Environment>> {
+        self.environments
+            .iter()
+            .find(|e| e.metadata().alias == environment_alias)
+            .map(|e| e.clone())
+    }
+}


### PR DESCRIPTION
This adds basic support for resetting the data state associated with an environment, optionally leaving the node or client state intact.

Closes #31 