### PR TITLE
fix(tests): update default penumbra version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Run tests with nextest
-        run: cargo nextest run --release
+        run: cargo nextest run --release --all-features
         env:
           CARGO_TERM_COLOR: always
 

--- a/justfile
+++ b/justfile
@@ -5,8 +5,8 @@ check:
 
 # Run unit tests
 test:
-  cargo test
+  cargo nextest run
 
 # Run network integration tests
-integration-test:
-  cargo test --features network-integration
+integration:
+  cargo nextest run --features network-integration

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6,7 +6,7 @@ use assert_cmd::Command;
 use tempfile::tempdir;
 
 /// The version of the CLI programs to fetch from github.
-const PENUMBRA_VERSION: &str = "0.80";
+const PENUMBRA_VERSION: &str = "2";
 
 /// For better or worse, the `penv manage create <foo>` command fails, unless
 /// `penv manage install <version>` was run first. When we add auto-installation

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -5,6 +5,7 @@
 use assert_cmd::Command;
 use tempfile::tempdir;
 
+/// The version of the CLI programs to fetch from github.
 const PENUMBRA_VERSION: &str = "0.80";
 
 /// For better or worse, the `penv manage create <foo>` command fails, unless


### PR DESCRIPTION
The CLI changes for pclientd/pcli in v1.5.0 [0], so while penv does
support the new-style, it doesn't handle historical versions smartly.
Let's just bump the integration tests to use the latest, which is a
realistic scenario anyway.

[0] https://github.com/penumbra-zone/penumbra/releases/tag/v1.5.0