### PR TITLE
lint: cargo clippy

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,8 +4,8 @@ check:
   RUSTFLAGS="-D warnings" cargo check --all-targets --all-features --target-dir=target/check
   # fmt dry-run, failing on any suggestions
   cargo fmt --all -- --check
-  # cargo clippy
   # clippy doesn't pass yet
+  # cargo clippy
 
 # Run unit tests
 test:

--- a/src/penv/environment/environment/binary/environment.rs
+++ b/src/penv/environment/environment/binary/environment.rs
@@ -66,7 +66,7 @@ impl<'de> Deserialize<'de> for BinaryEnvironment {
             {
                 struct FieldVisitor;
 
-                impl<'de> Visitor<'de> for FieldVisitor {
+                impl Visitor<'_> for FieldVisitor {
                     type Value = Field;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/penv/penv.rs
+++ b/src/penv/penv.rs
@@ -91,7 +91,7 @@ impl<'de> Deserialize<'de> for Penv {
             {
                 struct FieldVisitor;
 
-                impl<'de> Visitor<'de> for FieldVisitor {
+                impl Visitor<'_> for FieldVisitor {
                     type Value = Field;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/penv/release/release/binary.rs
+++ b/src/penv/release/release/binary.rs
@@ -71,7 +71,7 @@ impl<'de> Deserialize<'de> for InstalledBinaryRelease {
             {
                 struct FieldVisitor;
 
-                impl<'de> Visitor<'de> for FieldVisitor {
+                impl Visitor<'_> for FieldVisitor {
                     type Value = Field;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/penv/release/version.rs
+++ b/src/penv/release/version.rs
@@ -36,10 +36,7 @@ impl FromStr for RepoOrVersionReq {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Attempt to parse as a VersionReqOrLatest...
-        let version_or_latest = match VersionReqOrLatest::from_str(s) {
-            Ok(version_or_latest) => Some(version_or_latest),
-            Err(_) => None,
-        };
+        let version_or_latest = VersionReqOrLatest::from_str(s).ok();
 
         if let Some(version_or_latest) = version_or_latest {
             return Ok(Self::VersionReqOrLatest(version_or_latest));
@@ -75,10 +72,7 @@ impl FromStr for RepoOrVersion {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Attempt to parse as a Version...
-        let version = match Version::from_str(s) {
-            Ok(version) => Some(version),
-            Err(_) => None,
-        };
+        let version = Version::from_str(s).ok();
 
         match version {
             Some(version) => Ok(Self::Version(version)),


### PR DESCRIPTION
Runs `cargo clippy --fix` and commits the results. The clippy checks still fail: there are a lot of option unwraps throughout the codebase.